### PR TITLE
fix frontend using wrong index.html file

### DIFF
--- a/src/mafiasi_link_shortener/frontend/views.py
+++ b/src/mafiasi_link_shortener/frontend/views.py
@@ -32,7 +32,7 @@ class FrontendServer(WhiteNoiseMiddleware):
             and self.url_is_canonical(request.path_info)
             and request.path_info.startswith(self.static_prefix)
         ):
-            static_file = self.files.get(f"{self.static_prefix}/index.html")
+            static_file = self.files.get(f"{self.static_prefix}/index.post.html")
 
         if static_file is None:
             raise ValueError(


### PR DESCRIPTION
The frontend is configured at container startup at which point some template variables in index.html are replaced by actual configuration. 
The previous implementation was serving the template index.html which still included the templates which are invalid javascript.